### PR TITLE
Fix incorrect value in lookup table

### DIFF
--- a/ExperienceMod/src/main/java/com/comphenix/xp/rewards/xp/ExperienceManager.java
+++ b/ExperienceMod/src/main/java/com/comphenix/xp/rewards/xp/ExperienceManager.java
@@ -91,7 +91,7 @@ public class ExperienceManager {
 		for (int i = 1; i < xpTotalToReachLevel.length; i++) {
 			xpRequiredForNextLevel[i - 1] = incr;
 			xpTotalToReachLevel[i] = xpTotalToReachLevel[i - 1] + incr;
-			if (i >= 30) {
+			if (i >= 31) {
 				incr += 7;
 			} else if (i >= 16) {
 				incr += 3;


### PR DESCRIPTION
Hi there, I noticed while testing this out on minecraft 1.4.6 that the experience tables are incorrect for levels higher than 31.
http://www.minecraftwiki.net/wiki/Experience#Leveling_Up
