### PR TITLE
Fixed CURRENCY player parameter not working

### DIFF
--- a/ExperienceMod/src/main/java/com/comphenix/xp/ExperienceMod.java
+++ b/ExperienceMod/src/main/java/com/comphenix/xp/ExperienceMod.java
@@ -110,6 +110,7 @@ public class ExperienceMod extends JavaPlugin implements Debugger {
 	private HistoryProviders historyProviders;
 	private ParameterProviderSet parameterProviders;
 	private StandardPlayerService standardPlayerService;
+	private RewardEconomy rewardEconomy;
 	
 	private GlobalSettings globalSettings;
 	private ConfigurationLoader configLoader;
@@ -242,7 +243,7 @@ public class ExperienceMod extends JavaPlugin implements Debugger {
 			// Don't register economy rewards unless we can
 			if (hasEconomy()) {
 				itemListener = new ItemRewardListener(this);
-				RewardEconomy rewardEconomy = new RewardEconomy(economy, this, itemListener);
+				rewardEconomy = new RewardEconomy(economy, this, itemListener);
 				
 				// Associate everything
 				rewardProvider.register(rewardEconomy);
@@ -283,6 +284,8 @@ public class ExperienceMod extends JavaPlugin implements Debugger {
 			} catch (IOException e) {
 				currentLogger.severe("IO error when loading configurations: " + e.getMessage());
 			}
+			
+			xpMobListener.setEconomy(rewardEconomy);
 			
 			// Create memory history
 			historyProviders.register(new MemoryService(

--- a/ExperienceMod/src/main/java/com/comphenix/xp/ExperienceMod.java
+++ b/ExperienceMod/src/main/java/com/comphenix/xp/ExperienceMod.java
@@ -109,6 +109,7 @@ public class ExperienceMod extends JavaPlugin implements Debugger {
 	private CustomBlockProviders customProvider;
 	private HistoryProviders historyProviders;
 	private ParameterProviderSet parameterProviders;
+	private StandardPlayerService standardPlayerService;
 	
 	private GlobalSettings globalSettings;
 	private ConfigurationLoader configLoader;
@@ -182,7 +183,8 @@ public class ExperienceMod extends JavaPlugin implements Debugger {
 			
 			// Initialize parameter providers
 			parameterProviders = new ParameterProviderSet();
-			parameterProviders.registerPlayer(new StandardPlayerService(rewardProvider));
+			standardPlayerService = new StandardPlayerService();
+			parameterProviders.registerPlayer(standardPlayerService);
 			
 			// Initialize configuration loader
 			configLoader = new ConfigurationLoader(getDataFolder(), this, 
@@ -245,6 +247,7 @@ public class ExperienceMod extends JavaPlugin implements Debugger {
 				// Associate everything
 				rewardProvider.register(rewardEconomy);
 				itemListener.setReward(rewardEconomy);
+				standardPlayerService.setEconomy(rewardEconomy);
 				
 				// Inform the player
 				currentLogger.info("Economy enabled. Using " + economy.getName() + ".");

--- a/ExperienceMod/src/main/java/com/comphenix/xp/expressions/StandardPlayerService.java
+++ b/ExperienceMod/src/main/java/com/comphenix/xp/expressions/StandardPlayerService.java
@@ -34,11 +34,13 @@ public class StandardPlayerService implements ParameterService<Player> {
 	private static String[] PARAM_NAMES = Utility.toStringArray(PlayerParameters.values());
 	
 	// Used to support the currency parameter
-	protected RewardEconomy economy;
+	protected RewardEconomy economy = null;
 	
-	public StandardPlayerService(RewardProvider provider) {
-		// Load the economy provider
-		economy = (RewardEconomy) provider.getByEnum(RewardTypes.ECONOMY);
+	public StandardPlayerService() {
+	}
+	
+	public void setEconomy(RewardEconomy economy) {
+		this.economy = economy;
 	}
 	
 	@Override

--- a/ExperienceMod/src/main/java/com/comphenix/xp/rewards/xp/RewardEconomy.java
+++ b/ExperienceMod/src/main/java/com/comphenix/xp/rewards/xp/RewardEconomy.java
@@ -105,7 +105,7 @@ public class RewardEconomy implements RewardService {
 	}
 	
 	// Internal method
-	private boolean economyReward(Player player, int amount, Debugger debugger) {
+	public boolean economyReward(Player player, int amount, Debugger debugger) {
 		if (player == null)
 			throw new NullArgumentException("player");
 		

--- a/ExperienceMod/src/test/java/com/comphenix/xp/ConfigurationLoaderTest.java
+++ b/ExperienceMod/src/test/java/com/comphenix/xp/ConfigurationLoaderTest.java
@@ -26,7 +26,7 @@ public class ConfigurationLoaderTest implements Debugger {
 		provider.register(new RewardVirtual());
 		
 		ParameterProviderSet parameterProviders = new ParameterProviderSet();
-		parameterProviders.registerPlayer(new StandardPlayerService(provider));
+		parameterProviders.registerPlayer(new StandardPlayerService());
 
 		File root = new File(path);
 		ConfigurationLoader loader = new ConfigurationLoader(root, this, provider, new ChannelProvider(), parameterProviders);


### PR DESCRIPTION
Hey again aadnk I noticed the currency parameter could never work due to their being no economy provider when it was initialized. I fixed it up by setting the reference to the reward economy later.
